### PR TITLE
Add singleton-lock Do.config

### DIFF
--- a/do.gemspec
+++ b/do.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'gli', '~> 2.17', '>= 2.17.1'
   s.add_runtime_dependency('chronic','~> 0.10', '>= 0.10.2')
   s.add_runtime_dependency 'deep_merge', '~> 0'
+  s.add_runtime_dependency 'ostruct', '~> 0'
 end

--- a/lib/do/config.rb
+++ b/lib/do/config.rb
@@ -1,123 +1,46 @@
-class Config
-  attr_accessor :config,
-                :current_section,
-                :default_template,
-                :default_date_format
+require 'ostruct'
+require 'deep_merge'
 
-  # Config values come from three locations, in order of least -> most
+class Config
+  FILE_NAME = '.dorc'
+  # Config values come from three locations, in order of most to least
   # precedence
-  # 1. Defaults
-  # 2. ~/.doingrc
-  # 3. current working directory .doingrc
+  # 1. local_config   `pwd`/.dorc
+  # 2. global_config  ~/.dorc
+  # 3. Defaults       {}
   def initialize
+    @combined_config = defaults.deep_merge(global_config).deep_merge(local_config)
   end
+
+  def attributes
+    OpenStruct.new(@combined_config)
+  end
+
+  private
 
   def defaults
-    @default_config_file = '.doingrc'
-    @timers = {}
-
-    @config = read_config
-    user_config = @config.dup
-
-    @config['autotag'] ||= {}
-    @config['autotag']['whitelist'] ||= []
-    @config['autotag']['synonyms'] ||= {}
-    @config['doing_file'] ||= "~/what_was_i_doing.md"
-    @config['current_section'] ||= 'Currently'
-    @config['editor_app'] ||= nil
-    @config['templates'] ||= {}
-    @config['templates']['default'] ||= {
-      'date_format' => '%Y-%m-%d %H:%M',
-      'template' => '%date | %title%note',
-      'wrap_width' => 0
+    {
+      wdid: '~/wdid.md',
+      current_section: 'Currently',
+      date_format: '%Y-%m-%d %H:%M'
     }
-    @config['templates']['today'] ||= {
-      'date_format' => '%_I:%M%P',
-      'template' => '%date: %title %interval%note',
-      'wrap_width' => 0
-    }
-    @config['templates']['last'] ||= {
-      'date_format' => '%-I:%M%P on %a',
-      'template' => '%title (at %date)%odnote',
-      'wrap_width' => 88
-    }
-    @config['templates']['recent'] ||= {
-      'date_format' => '%_I:%M%P',
-      'template' => '%shortdate: %title',
-      'wrap_width' => 88
-    }
-    @config['views'] ||= {
-      'done' => {
-        'date_format' => '%_I:%M%P',
-        'template' => '%date | %title%note',
-        'wrap_width' => 0,
-        'section' => 'All',
-        'count' => 0,
-        'order' => 'desc',
-        'tags' => 'done complete cancelled',
-        'tags_bool' => 'OR'
-      },
-      'color' => {
-          'date_format' => '%F %_I:%M%P',
-          'template' => '%boldblack%date %boldgreen| %boldwhite%title%default%note',
-          'wrap_width' => 0,
-          'section' => 'Currently',
-          'count' => 10,
-          'order' => "asc"
-      }
-    }
-    @config['marker_tag'] ||= 'flagged'
-    @config['marker_color'] ||= 'red'
-    @config['default_tags'] ||= []
-
-    @config[:include_notes] ||= true
-
-    File.open(@config_file, 'w') { |yf| YAML::dump(@config, yf) } if @config != user_config || @doingrc_needs_update
-
-
-    @config = @config.deep_merge(@local_config)
-
-    @current_section = @config['current_section']
-    @default_template = @config['templates']['default']['template']
-    @default_date_format = @config['templates']['default']['date_format']
   end
 
-  def find_local_config
-
-    config = {}
-    dir = Dir.pwd
-
-    local_config_file = nil
-
-    while (dir != '/' && (dir =~ /[A-Z]:\//) == nil)
-      if File.exists? File.join(dir, @default_config_file)
-        return File.join(dir, @default_config_file)
-      end
-
-      dir = File.dirname(dir)
-    end
-
-    false
-  end
-
-  def read_config
-    if Dir.respond_to?('home')
-      @config_file = File.join(Dir.home, @default_config_file)
+  def global_config
+    global_config_file = File.expand_path(File.join('~', FILE_NAME))
+    if File.file?(global_config_file)
+      YAML.load_file(global_config_file)
     else
-      @config_file = File.join(File.expand_path("~"), @default_config_file)
-    end
-    @doingrc_needs_update = true if File.exists? @config_file
-    additional = find_local_config
-
-    begin
-      @config = YAML.load_file(@config_file) || {} if File.exists?(@config_file)
-      @local_config = YAML.load_file(additional) || {} if additional
-      @config.deep_merge(@local_config)
-    rescue
-      @config = {}
-      @local_config = {}
-      # raise "error reading config"
+      File.open(global_config_file, 'w') do |file|
+        YAML.dump(defaults, file)
+      end
     end
   end
 
+  def local_config
+    local_config_file = File.expand_path(File.join(Dir.pwd, FILE_NAME))
+    if File.file?(local_config_file)
+      YAML.load_file(local_config_file)
+    end
+  end
 end

--- a/lib/do/do.rb
+++ b/lib/do/do.rb
@@ -1,7 +1,8 @@
 module Do
   class << self
     def config
-      @config ||= Config.new
+      c = Config.new
+      @config ||= c.attributes
     end
   end
 end

--- a/spec/do/config_spec.rb
+++ b/spec/do/config_spec.rb
@@ -1,0 +1,12 @@
+require 'do'
+
+describe 'Do.config' do
+  it 'returns the default config' do
+    expect(Do.config).to eq(OpenStruct.new({
+      wdid: '~/wdid.md',
+      config_file: '.dorc',
+      current_section: 'Currently',
+      date_format: '%Y-%m-%d %H:%M'
+    }))
+  end
+end


### PR DESCRIPTION
Merge the default config, global config, and a local config into a
single, global, config object. This makes it so other parts of the Do
module do not need to initialize their own configuarion object.

https://github.com/benortiz/do/issues/1