### PR TITLE
Add add/find methods for Taskpaper

### DIFF
--- a/lib/do/taskpaper/note.rb
+++ b/lib/do/taskpaper/note.rb
@@ -1,8 +1,6 @@
 class Taskpaper::Note
   NOTE_LINE = /^\t\t([\w\s]+)/
 
-  attr_reader :lines
-
   def initialize(task:, lines: [])
     @task = task
     @lines = lines

--- a/lib/do/taskpaper/outline.rb
+++ b/lib/do/taskpaper/outline.rb
@@ -1,20 +1,38 @@
 class Taskpaper::Outline
-  attr_accessor :raw_content
+  attr_accessor :projects
 
   def initialize(raw_content:)
-    self.raw_content = raw_content
+    @raw_content = raw_content
   end
 
-  # PONDER:
-  #   - Just pass the line into the other classes and have them handle the
-  #   parsing.
-  #   - Is there another way besides nil + .compact?
+  def to_s
+    projects.map(&:to_s).reduce(:+)
+  end
+
+  def find_project(name)
+    projects.detect { |project| project.name == name }
+  end
+
+  def add_project(project)
+    projects << project
+  end
+
+  def projects
+    @projects ||= to_structure
+  end
+
+  def tasks
+    projects.map(&:tasks).flatten
+  end
+
+  private
+
   # Take a StringIO and turns it into an array of Taskpaper::Projects
   def to_structure
     project = Taskpaper::Project.new(name: "Uncategorized")
     task = nil
 
-    raw_content.lines.map do |line|
+    @raw_content.lines.map do |line|
       next if line.strip.empty?
       if line =~ Taskpaper::Project::PROJECT_LINE
         project_name = $1
@@ -33,28 +51,5 @@ class Taskpaper::Outline
         nil
       end
     end.compact
-  end
-
-  # Turn the structured taskpaper into a string for writting to some storage
-  def to_s
-    to_structure.map(&:to_s).reduce(:+)
-  end
-
-  def add_project
-  end
-
-  def find_project
-  end
-
-  def projects
-  end
-
-  def add_task
-  end
-
-  def find_task
-  end
-
-  def tasks
   end
 end

--- a/lib/do/taskpaper/project.rb
+++ b/lib/do/taskpaper/project.rb
@@ -2,6 +2,7 @@ class Taskpaper::Project
   PROJECT_LINE = /^(\S[\S ]+):\s*(@\S+\s*)*$/
 
   attr_accessor :tasks
+  attr_reader :name
 
   def initialize(name:)
     @name = name

--- a/lib/do/taskpaper/task.rb
+++ b/lib/do/taskpaper/task.rb
@@ -2,6 +2,7 @@ class Taskpaper::Task
   TASK_LINE = /^\s*- (\d{4}-\d\d-\d\d \d\d:\d\d) \| (.*)/
 
   attr_accessor :note
+  attr_reader :project, :note
 
   def initialize(project:, description:, date:)
     @project = project

--- a/lib/do/taskpaper/task.rb
+++ b/lib/do/taskpaper/task.rb
@@ -15,8 +15,9 @@ class Taskpaper::Task
     "\t- #{formatted_date} | #{@description}\n#{@note.to_s}"
   end
 
+  private
+
   def formatted_date
     @date.strftime(Taskpaper.config.date_format)
   end
-
 end

--- a/spec/taskpaper/note_spec.rb
+++ b/spec/taskpaper/note_spec.rb
@@ -13,7 +13,7 @@ describe 'Taskpaper::Note' do
     it 'appends the line to the lines array' do
       note = Taskpaper::Note.new(task: nil, lines: ['note'])
       note.add_line('note1')
-      expect(note.lines).to eq(['note', 'note1'])
+      expect(note.instance_variable_get(:@lines)).to eq(['note', 'note1'])
     end
   end
 end

--- a/spec/taskpaper/outline_spec.rb
+++ b/spec/taskpaper/outline_spec.rb
@@ -4,9 +4,9 @@ describe 'Taskpaper::Outline' do
   subject do
     Taskpaper::Outline.new(raw_content: "Currently:\n\t- 2018-09-17 20:04 | something i did\n")
   end
-  describe '#to_structure' do
+  describe '#projects' do
     it 'takes a string and breaks it into an array of projects' do
-      expect(subject.to_structure.length).to eq(1)
+      expect(subject.projects.length).to eq(1)
     end
   end
 
@@ -15,4 +15,24 @@ describe 'Taskpaper::Outline' do
       expect(subject.to_s).to eq("Currently:\n\t- 2018-09-17 20:04 | something i did\n")
     end
   end
+
+  describe '#find_project' do
+    it 'finds a project in an outline by name' do
+      expect(subject.find_project('Currently')).to be
+    end
+  end
+
+  describe '#add_project' do
+    it 'appends a project to the taskpaper outline' do
+      subject.add_project(Taskpaper::Project.new(name: 'New Project'))
+      expect(subject.projects.length).to eq(2)
+    end
+  end
+
+  describe '#tasks' do
+    it 'lists all the tasks in all the projects' do
+      expect(subject.tasks.length).to eq(1)
+    end
+  end
+
 end


### PR DESCRIPTION
A Taskpaper::Outline can find projects by name and add new projects to the
outline. It can also list all projects and tasks. This sets us up to easily
manipulate a Taskpaper without needing to regex each time we want to edit
it.